### PR TITLE
Allow iterating through entries by using #each or #each_pair

### DIFF
--- a/lib/closed_struct.rb
+++ b/lib/closed_struct.rb
@@ -29,4 +29,13 @@ class ClosedStruct
   def empty?
     @contents.empty?
   end
+
+  def each
+    return enum_for(:each) unless block_given?
+
+    @contents.each do |key, value|
+      yield key, value
+    end
+  end
+  alias_method :each_pair, :each
 end

--- a/lib/closed_struct.rb
+++ b/lib/closed_struct.rb
@@ -30,12 +30,11 @@ class ClosedStruct
     @contents.empty?
   end
 
-  def each
-    return enum_for(:each) unless block_given?
+  def each_pair
+    return enum_for(:each_pair) unless block_given?
 
-    @contents.each do |key, value|
+    @contents.each_pair do |key, value|
       yield key, value
     end
   end
-  alias_method :each_pair, :each
 end

--- a/spec/closed_struct_spec.rb
+++ b/spec/closed_struct_spec.rb
@@ -60,27 +60,25 @@ describe ClosedStruct do
     expect(ClosedStruct.new(:a => :b).empty?).to be_falsey
   end
 
-  %w(each each_pair).each do |method_name|
-    describe "##{method_name}" do
-      it "does not yield when empty" do
-        object = ClosedStruct.new({})
-        expect { |b| object.send(method_name, &b) }.to_not yield_control
-      end
+  describe "#each_pair" do
+    it "does not yield when empty" do
+      object = ClosedStruct.new({})
+      expect { |b| object.each_pair(&b) }.to_not yield_control
+    end
 
-      it "yields a key-value pair for a key in the hash" do
-        object = ClosedStruct.new(:a => :b)
-        expect { |b| object.send(method_name, &b) }.to yield_with_args(:a, :b)
-      end
+    it "yields a key-value pair for a key in the hash" do
+      object = ClosedStruct.new(:a => :b)
+      expect { |b| object.each_pair(&b) }.to yield_with_args(:a, :b)
+    end
 
-      it "yields a key-value pair for each key in the hash" do
-        object = ClosedStruct.new(:a => :b, :c => :d)
-        expect { |b| object.send(method_name, &b) }.to yield_successive_args([:a, :b], [:c, :d])
-      end
+    it "yields a key-value pair for each key in the hash" do
+      object = ClosedStruct.new(:a => :b, :c => :d)
+      expect { |b| object.each_pair(&b) }.to yield_successive_args([:a, :b], [:c, :d])
+    end
 
-      it "returns an enumerator if a block is not provided" do
-        expect(ClosedStruct.new(:a => :b).send(method_name)).to be_an(Enumerator)
-        expect(ClosedStruct.new({}).send(method_name)).to be_an(Enumerator)
-      end
+    it "returns an enumerator if a block is not provided" do
+      expect(ClosedStruct.new(:a => :b).each_pair).to be_an(Enumerator)
+      expect(ClosedStruct.new({}).each_pair).to be_an(Enumerator)
     end
   end
 end

--- a/spec/closed_struct_spec.rb
+++ b/spec/closed_struct_spec.rb
@@ -60,4 +60,27 @@ describe ClosedStruct do
     expect(ClosedStruct.new(:a => :b).empty?).to be_falsey
   end
 
+  %w(each each_pair).each do |method_name|
+    describe "##{method_name}" do
+      it "does not yield when empty" do
+        object = ClosedStruct.new({})
+        expect { |b| object.send(method_name, &b) }.to_not yield_control
+      end
+
+      it "yields a key-value pair for a key in the hash" do
+        object = ClosedStruct.new(:a => :b)
+        expect { |b| object.send(method_name, &b) }.to yield_with_args(:a, :b)
+      end
+
+      it "yields a key-value pair for each key in the hash" do
+        object = ClosedStruct.new(:a => :b, :c => :d)
+        expect { |b| object.send(method_name, &b) }.to yield_successive_args([:a, :b], [:c, :d])
+      end
+
+      it "returns an enumerator if a block is not provided" do
+        expect(ClosedStruct.new(:a => :b).send(method_name)).to be_an(Enumerator)
+        expect(ClosedStruct.new({}).send(method_name)).to be_an(Enumerator)
+      end
+    end
+  end
 end

--- a/spec/closed_struct_spec.rb
+++ b/spec/closed_struct_spec.rb
@@ -77,8 +77,8 @@ describe ClosedStruct do
     end
 
     it "returns an enumerator if a block is not provided" do
-      expect(ClosedStruct.new(:a => :b).each_pair).to be_an(Enumerator)
-      expect(ClosedStruct.new({}).each_pair).to be_an(Enumerator)
+      expect(ClosedStruct.new(:a => :b).each_pair).to contain_exactly([:a, :b])
+      expect(ClosedStruct.new({}).each_pair).to_not include(anything)
     end
   end
 end


### PR DESCRIPTION
Implements `each` and `each_pair` so that the contents of the ClosedStruct can be iterated.