### PR TITLE
Coerse ClosedStruct to Hash

### DIFF
--- a/lib/closed_struct.rb
+++ b/lib/closed_struct.rb
@@ -16,6 +16,7 @@ class ClosedStruct
   def to_h
     @contents
   end
+  alias_method :to_hash, :to_h
 
   def hash
     @contents.hash

--- a/spec/closed_struct_spec.rb
+++ b/spec/closed_struct_spec.rb
@@ -39,6 +39,11 @@ describe ClosedStruct do
     expect(object.something).to eq(:value)
   end
 
+  it "behaves like an hash" do
+    object = ClosedStruct.new(:a => :b)
+    expect{ {:a => :d}.merge(object) }.not_to raise_error
+  end
+
   it "is indifferent to the input getting mutated" do
     input = {:a => :b}
     object = ClosedStruct.new(input)


### PR DESCRIPTION
This makes ClosedStruct able to behave like an Hash.

imagine the following method:
```ruby
def create_connection(ip:, port:, **)
  puts "connecting to #{ip}:#{port}"
  # doing crazy stuffs [...]
end
```
The `ip` and `port` are both available in my config struct:
```ruby
class Configuration < ClosedStruct
  def initialize(port: 80, ip: '192.168.1.1')
    super(port: port, ip: ip)
  end
end
```
I want to directly pass the struct into the method using the double splat operator like this: 
``` ruby
config = Configuration.new(port: 8080)
create_connection(**config)
# "connecting to 192.168.1.1:8080"
```
